### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - nightly
+
+matrix:
+    allow_failures:
+        - php: nightly
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "symfony/yaml": "^3.0 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^5.7 || ^6.5",
         "friendsofphp/php-cs-fixer": "^2.3"
     },
     "autoload": {

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHLAK\Config;
+use PHPUnit\Framework\TestCase;
 
-class ArrayTest extends PHPUnit_Framework_TestCase
+class ArrayTest extends TestCase
 {
     public function test_it_can_initialize_an_array()
     {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHLAK\Config;
+use PHPUnit\Framework\TestCase;
 
-class ConfigTest extends PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     public function test_it_can_set_and_retrieve_an_item()
     {
@@ -117,10 +118,11 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->assertNull($bar->get('foo'));
     }
 
+    /**
+     * @expectedException PHLAK\Config\Exceptions\InvalidContextException
+     */
     public function test_it_throws_an_exception_when_initialized_with_an_invalid_context()
     {
-        $this->setExpectedException(Config\Exceptions\InvalidContextException::class);
-
         new Config\Config(123);
     }
 
@@ -176,7 +178,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         ]);
 
         foreach ($config as $item) {
-            $this->assertTrue($item);
+            $this->assertTrue($value);
         }
     }
 }

--- a/tests/DirectoryTest.php
+++ b/tests/DirectoryTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHLAK\Config;
+use PHPUnit\Framework\TestCase;
 
-class DirectoryTest extends PHPUnit_Framework_TestCase
+class DirectoryTest extends TestCase
 {
     public function test_it_can_initialize_a_directory()
     {

--- a/tests/IniTest.php
+++ b/tests/IniTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHLAK\Config;
+use PHPUnit\Framework\TestCase;
 
-class IniTest extends PHPUnit_Framework_TestCase
+class IniTest extends TestCase
 {
     use Initializable;
 

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHLAK\Config;
+use PHPUnit\Framework\TestCase;
 
-class JsonTest extends PHPUnit_Framework_TestCase
+class JsonTest extends TestCase
 {
     use Initializable;
 

--- a/tests/PhpTest.php
+++ b/tests/PhpTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHLAK\Config;
+use PHPUnit\Framework\TestCase;
 
-class PhpTest extends PHPUnit_Framework_TestCase
+class PhpTest extends TestCase
 {
     use Initializable;
 

--- a/tests/XmlTest.php
+++ b/tests/XmlTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHLAK\Config;
+use PHPUnit\Framework\TestCase;
 
-class XmlTest extends PHPUnit_Framework_TestCase
+class XmlTest extends TestCase
 {
     use Initializable;
 

--- a/tests/YamlTest.php
+++ b/tests/YamlTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use PHLAK\Config;
+use PHPUnit\Framework\TestCase;
 
-class YamlTest extends PHPUnit_Framework_TestCase
+class YamlTest extends TestCase
 {
     use Initializable;
 
@@ -12,10 +13,11 @@ class YamlTest extends PHPUnit_Framework_TestCase
         $this->invalidConfig = __DIR__ . '/files/yaml/invalid.yaml';
     }
 
+    /**
+     * @expectedException PHLAK\Config\Exceptions\InvalidFileException
+     */
     public function test_it_throws_an_exception_when_initializing_a_yaml_file_without_an_array()
     {
-        $this->setExpectedException(Config\Exceptions\InvalidFileException::class);
-
         new Config\Config(__DIR__ . '/files/yaml/bad.yaml');
     }
 }

--- a/tests/traits/Initializable.php
+++ b/tests/traits/Initializable.php
@@ -18,10 +18,11 @@ trait Initializable
         $this->assertEquals('database.sqlite', $config->get('drivers.sqlite.database'));
     }
 
+    /**
+     * @expectedException PHLAK\Config\Exceptions\InvalidFileException
+     */
     public function test_it_throws_an_exception_when_initializing_an_invalid_file()
     {
-        $this->setExpectedException(Config\Exceptions\InvalidFileException::class);
-
         new Config\Config($this->invalidConfig);
     }
 


### PR DESCRIPTION
# Changed log
- Use class-based PHPUnit namespace to be compatible with latest PHPHUnit version.
- Add ```php-nightly``` test and allow this to be failed in Travis CI build.
- Fix the ```foreachable``` assertions.
- After the PHPUnit version ```6.0```, the ```setExpectedException``` is deprecated.
To be compatible with the ```5.7```, we should use the expected exception annotation.