### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 php:
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.3",
-        "phpunit/phpunit": "^6.0 || ^7.0",
+        "phpunit/phpunit": "^6.0 || ^7.0 || ^8.0",
         "psy/psysh": "^0.9.6"
     },
     "autoload": {

--- a/tests/IniTest.php
+++ b/tests/IniTest.php
@@ -10,7 +10,7 @@ class IniTest extends TestCase
 {
     use Initializable;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->validConfig = __DIR__ . '/files/ini/config.ini';
         $this->invalidConfig = __DIR__ . '/files/ini/invalid.ini';

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -10,7 +10,7 @@ class JsonTest extends TestCase
 {
     use Initializable;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->validConfig = __DIR__ . '/files/json/config.json';
         $this->invalidConfig = __DIR__ . '/files/json/invalid.json';

--- a/tests/PhpTest.php
+++ b/tests/PhpTest.php
@@ -10,7 +10,7 @@ class PhpTest extends TestCase
 {
     use Initializable;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->validConfig = __DIR__ . '/files/php/config.php';
         $this->invalidConfig = __DIR__ . '/files/php/invalid.php';

--- a/tests/TomlTest.php
+++ b/tests/TomlTest.php
@@ -11,7 +11,7 @@ class TomlTest extends TestCase
 {
     use Initializable;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->validConfig = __DIR__ . '/files/toml/config.toml';
         $this->invalidConfig = __DIR__ . '/files/toml/invalid.toml';

--- a/tests/XmlTest.php
+++ b/tests/XmlTest.php
@@ -10,7 +10,7 @@ class XmlTest extends TestCase
 {
     use Initializable;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->validConfig = __DIR__ . '/files/xml/config.xml';
         $this->invalidConfig = __DIR__ . '/files/xml/invalid.xml';

--- a/tests/YamlTest.php
+++ b/tests/YamlTest.php
@@ -11,7 +11,7 @@ class YamlTest extends TestCase
 {
     use Initializable;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->validConfig = __DIR__ . '/files/yaml/config.yaml';
         $this->invalidConfig = __DIR__ . '/files/yaml/invalid.yaml';


### PR DESCRIPTION
# Changed log
- Add `php-7.3` test on Travis CI build.
- According to the [Fixtures reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), `PHPUnit\Framework\TestCase::setUp` should be `protected`, not `public`.