### PR TITLE
Updated for php 8.1 & removed deprecated warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "symfony/yaml": "^3.0 || ^4.0 || ^5.0 || ^6.0",
+        "php": ">=8.1",
+        "symfony/yaml": "^6.0",
         "yosymfony/toml": "^1.0"
     },
     "require-dev": {
         "phlak/coding-standards": "^2.0",
         "psy/psysh": "^0.11",
-        "vimeo/psalm": "^4.7",
-        "yoast/phpunit-polyfills": "^1.0"
+        "vimeo/psalm": "^5.15",
+        "yoast/phpunit-polyfills": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
->
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage/>
   <testsuites>
     <testsuite name="PHLAK/Config Test Suite">
       <directory suffix="Test.php">tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd">
   <coverage/>
   <testsuites>
     <testsuite name="PHLAK/Config Test Suite">

--- a/src/Config.php
+++ b/src/Config.php
@@ -208,7 +208,7 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * Load configuration options from a file or directory.
      *
      * @param string $path Path to configuration file or directory
-     * @param string|null $prefix A key under which the loaded config will be nested
+     * @param string $prefix A key under which the loaded config will be nested
      * @param bool $override Whether to override existing options with
      *                       values from the loaded file
      *

--- a/src/Config.php
+++ b/src/Config.php
@@ -167,7 +167,8 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * @param mixed $value Config item value
      *
      * @return true
-     *@throws RuntimeException
+     *
+     * @throws RuntimeException
      *
      */
     public function prepend(string $key, mixed $value): bool

--- a/src/Config.php
+++ b/src/Config.php
@@ -139,7 +139,8 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * @param mixed $value Config item value
      *
      * @return true
-     *@throws RuntimeException
+     *
+     * @throws RuntimeException
      *
      */
     public function append(string $key, mixed $value): bool

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,7 +24,7 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * @param mixed $context Raw array of configuration options or path to a
      *                       configuration file or directory containing one or
      *                       more configuration files
-     * @param string|null $prefix A key under which the loaded config will be nested
+     * @param string|array $prefix A key under which the loaded config will be nested
      * @throws InvalidContextException
      */
     public function __construct($context = null, string $prefix = null)

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,7 +24,8 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * @param mixed $context Raw array of configuration options or path to a
      *                       configuration file or directory containing one or
      *                       more configuration files
-     * @param string $prefix A key under which the loaded config will be nested
+     * @param string|null $prefix A key under which the loaded config will be nested
+     * @throws InvalidContextException
      */
     public function __construct($context = null, string $prefix = null)
     {
@@ -75,7 +76,7 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      *
      * @return bool True on success, otherwise false
      */
-    public function set(string $key, $value): bool
+    public function set(string $key, mixed $value): bool
     {
         $config = &$this->config;
 
@@ -92,11 +93,11 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * Retrieve a configuration option via a provided key.
      *
      * @param string $key Unique configuration option key
-     * @param mixed $default Default value to return if option does not exist
+     * @param mixed|null $default Default value to return if option does not exist
      *
      * @return mixed Stored config item or $default value
      */
-    public function get(string $key, $default = null)
+    public function get(string $key, mixed $default = null): mixed
     {
         $config = $this->config;
 
@@ -115,7 +116,7 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      *
      * @param string $key Unique configuration option key
      *
-     * @return bool True if item existst, otherwise false
+     * @return bool True if item exists, otherwise false
      */
     public function has(string $key): bool
     {
@@ -137,11 +138,11 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * @param string $key Unique configuration option key
      * @param mixed $value Config item value
      *
-     * @throws RuntimeException
-     *
      * @return true
+     *@throws RuntimeException
+     *
      */
-    public function append(string $key, $value): bool
+    public function append(string $key, mixed $value): bool
     {
         $config = &$this->config;
 
@@ -150,7 +151,7 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
         }
 
         if (! is_array($config)) {
-            throw new RuntimeException("Config item '{$key}' is not an array");
+            throw new RuntimeException("Config item '$key' is not an array");
         }
 
         $config = array_merge($config, (array) $value);
@@ -164,11 +165,11 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * @param string $key Unique configuration option key
      * @param mixed $value Config item value
      *
-     * @throws RuntimeException
-     *
      * @return true
+     *@throws RuntimeException
+     *
      */
-    public function prepend(string $key, $value): bool
+    public function prepend(string $key, mixed $value): bool
     {
         $config = &$this->config;
 
@@ -177,7 +178,7 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
         }
 
         if (! is_array($config)) {
-            throw new RuntimeException("Config item '{$key}' is not an array");
+            throw new RuntimeException("Config item '$key' is not an array");
         }
 
         $config = array_merge((array) $value, $config);
@@ -205,11 +206,11 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * Load configuration options from a file or directory.
      *
      * @param string $path Path to configuration file or directory
-     * @param string $prefix A key under which the loaded config will be nested
-     * @param bool $override Whether or not to override existing options with
+     * @param string|null $prefix A key under which the loaded config will be nested
+     * @param bool $override Whether to override existing options with
      *                       values from the loaded file
      *
-     * @return \PHLAK\Config\Interfaces\ConfigInterface This Config object
+     * @return ConfigInterface This Config object
      */
     public function load(string $path, string $prefix = null, bool $override = true): ConfigInterface
     {
@@ -235,7 +236,7 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
      * Merge another Config object into this one.
      *
      * @param \PHLAK\Config\Interfaces\ConfigInterface $config Instance of Config
-     * @param bool $override Whether or not to override existing options with
+     * @param bool $override Whether to override existing options with
      *                       values from the merged config object
      *
      * @return \PHLAK\Config\Interfaces\ConfigInterface This Config object
@@ -252,11 +253,12 @@ class Config implements ConfigInterface, ArrayAccess, IteratorAggregate
     }
 
     /**
-     * Split a sub-array of configuration options into it's own config.
+     * Split a sub-array of configuration options into its own config.
      *
      * @param string $key Unique configuration option key
      *
      * @return \PHLAK\Config\Interfaces\ConfigInterface A new ConfigInterface object
+     * @throws InvalidContextException
      */
     public function split(string $key): ConfigInterface
     {

--- a/src/Interfaces/ConfigInterface.php
+++ b/src/Interfaces/ConfigInterface.php
@@ -10,7 +10,7 @@ interface ConfigInterface
      * @param array|string $context Raw array of configuration options or path to a
      *                              configuration file or directory containing one or
      *                              more configuration files
-     * @param string|null $prefix A key under which the loaded config will be nested
+     * @param string $prefix A key under which the loaded config will be nested
      */
     public function __construct($context = null, string $prefix = null);
 

--- a/src/Interfaces/ConfigInterface.php
+++ b/src/Interfaces/ConfigInterface.php
@@ -7,10 +7,10 @@ interface ConfigInterface
     /**
      * Create a new instance of a ConfigInterface object.
      *
-     * @param array|string $context Raw array of configuration options or path to a
+     * @param null $context Raw array of configuration options or path to a
      *                              configuration file or directory containing one or
      *                              more configuration files
-     * @param string $prefix A key under which the loaded config will be nested
+     * @param string|null $prefix A key under which the loaded config will be nested
      */
     public function __construct($context = null, string $prefix = null);
 
@@ -30,24 +30,24 @@ interface ConfigInterface
      *
      * @return bool True on success, otherwise false
      */
-    public function set(string $key, $value): bool;
+    public function set(string $key, mixed $value): bool;
 
     /**
      * Retrieve a configuration option via a provided key.
      *
      * @param string $key Unique configuration option key
-     * @param mixed $default Default value to return if option does not exist
+     * @param mixed|null $default Default value to return if option does not exist
      *
      * @return mixed Stored config item or $default value
      */
-    public function get(string $key, $default = null);
+    public function get(string $key, mixed $default = null): mixed;
 
     /**
      * Check for the existence of a configuration item.
      *
      * @param string $key Unique configuration option key
      *
-     * @return bool True if item existst, otherwise false
+     * @return bool True if item exists, otherwise false
      */
     public function has(string $key): bool;
 
@@ -61,7 +61,7 @@ interface ConfigInterface
      *
      * @return true
      */
-    public function append(string $key, $value): bool;
+    public function append(string $key, mixed $value): bool;
 
     /**
      * Prepend a value onto the beginning of an existing array configuration option.
@@ -73,7 +73,7 @@ interface ConfigInterface
      *
      * @return true
      */
-    public function prepend(string $key, $value): bool;
+    public function prepend(string $key, mixed $value): bool;
 
     /**
      * Unset a configuration option via a provided key.
@@ -88,9 +88,10 @@ interface ConfigInterface
      * Load configuration options from a file or directory.
      *
      * @param string $path Path to configuration file or directory
-     * @param string $prefix A key under which the loaded config will be nested
-     * @param bool $override Whether or not to override existing options with
+     * @param string|null $prefix A key under which the loaded config will be nested
+     * @param bool $override Whether to override existing options with
      *                       values from the loaded file
+     * @return ConfigInterface
      */
     public function load(string $path, string $prefix = null, bool $override = true): self;
 
@@ -98,7 +99,7 @@ interface ConfigInterface
      * Merge another instance of ConfigInterface into this one.
      *
      * @param self $config Instance of ConfigInterface
-     * @param bool $override Whether or not to override existing options with
+     * @param bool $override Whether to override existing options with
      *                       values from the merged config object
      *
      * @return self This ConfigInterface object

--- a/src/Interfaces/ConfigInterface.php
+++ b/src/Interfaces/ConfigInterface.php
@@ -7,7 +7,7 @@ interface ConfigInterface
     /**
      * Create a new instance of a ConfigInterface object.
      *
-     * @param null $context Raw array of configuration options or path to a
+     * @param array|string $context Raw array of configuration options or path to a
      *                              configuration file or directory containing one or
      *                              more configuration files
      * @param string|null $prefix A key under which the loaded config will be nested

--- a/src/Interfaces/ConfigInterface.php
+++ b/src/Interfaces/ConfigInterface.php
@@ -88,7 +88,7 @@ interface ConfigInterface
      * Load configuration options from a file or directory.
      *
      * @param string $path Path to configuration file or directory
-     * @param string|null $prefix A key under which the loaded config will be nested
+     * @param string $prefix A key under which the loaded config will be nested
      * @param bool $override Whether to override existing options with
      *                       values from the loaded file
      * @return ConfigInterface

--- a/src/Interfaces/Loadable.php
+++ b/src/Interfaces/Loadable.php
@@ -10,5 +10,5 @@ interface Loadable
      *
      * @return array Array of configuration options
      */
-    public function getArray();
+    public function getArray(): array;
 }

--- a/src/Loaders/Loader.php
+++ b/src/Loaders/Loader.php
@@ -7,7 +7,7 @@ use PHLAK\Config\Interfaces\Loadable;
 abstract class Loader implements Loadable
 {
     /** @var string Path to a configuration file or directory */
-    protected $context;
+    protected string $context;
 
     /**
      * Create a new Loader object.

--- a/src/Traits/Arrayable.php
+++ b/src/Traits/Arrayable.php
@@ -55,9 +55,9 @@ trait Arrayable
     /**
      * Unset an item at a specific offset.
      *
-     * @param $offset The offset to unset
+     * @param mixed $offset The offset to unset
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->config[$offset]);
     }

--- a/src/Traits/Arrayable.php
+++ b/src/Traits/Arrayable.php
@@ -8,9 +8,9 @@ use Traversable;
 trait Arrayable
 {
     /**
-     * Retrieve an the config array as an iterator.
+     * Retrieve the config array as an iterator.
      *
-     * @return Traversable The conifg as a traversable iterator
+     * @return Traversable The config as a traversable iterator
      */
     public function getIterator(): Traversable
     {
@@ -47,7 +47,7 @@ trait Arrayable
      * @param mixed $offset The offset to assign the value to
      * @param mixed $value The value to set
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->config[$offset] = $value;
     }


### PR DESCRIPTION
Hi, I love Config but ran into a few problems with PHP >=8.1, e.g. deprecated warnings.
I've updated an abandoned library as well, and updated the others to where support <8.1 wasn't required, and migrated the phpunit xml.
50 tests and 88 assertions ran ok.