### PR TITLE
fix : ignore extensions that do not have associated loader class

### DIFF
--- a/src/Loaders/Directory.php
+++ b/src/Loaders/Directory.php
@@ -26,6 +26,10 @@ class Directory extends Loader
             $className = $file->isDir() ? 'Directory' : ucfirst(strtolower($file->getExtension()));
             $classPath = 'PHLAK\\Config\\Loaders\\' . $className;
 
+            if (!class_exists($classPath)) {
+                continue;
+            }
+
             /** @var Loader $loader */
             $loader = new $classPath($file->getPathname());
 


### PR DESCRIPTION
Thanks for this awesome library , 
I am using this as the configuration engine for scrawler framework [https://github.com/scrawler-labs/scrawler](https://github.com/scrawler-labs/scrawler)

I have seen some shared hosting creating random weird files like .error_log inside config directory , this causes an error 
"Class PHLAK\Config\Loaders\Error_log" not found and causes scrawler's boot process to fail 

This PR checks if the relevant loader class exists for the file type , If the loader does not exists the file is ignored and other files are successfully loaded
